### PR TITLE
Lift the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styleguidist-knobs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A knob addon for react-styleguidist",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Hi! I want to use your module for styleguidist, but it incorrect in npmregistry (module.exports is "./addons/knobs/lib/index.js", must be ''styleguidist-knobs/lib/index.js'' like in repository now). You make some changes in code, but you forgot to lift the version. Can you update the version and put package in npmregisty?) Thanks.